### PR TITLE
Fix README test path

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,10 +80,10 @@ public void AnotherMethod()
 
 This project includes xUnit tests covering core behaviors of `DeferContext` and the `Defer` helper.
 
-1. Navigate to the `tests/Deferly.Tests` folder.  
+1. Navigate to the `tests/Deferly.Tests` folder.
 2. Run `dotnet test`:
    ```bash
-   cd tests/Defer.Tests
+   cd tests/Deferly.Tests
    dotnet test
    ```
 ---


### PR DESCRIPTION
## Summary
- correct the instructions for running tests

## Testing
- `dotnet test tests/Deferly.Tests/Deferly.Tests.csproj -nologo` *(fails: dotnet not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68586cba0ff8832d97cae8aabfaf1367